### PR TITLE
Merge pull request #598 from everx-labs/fix-cell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## Version 1.11.19
+
+- Deleted deprecated method CellImpl::cell_data
+
 ## Version 1.11.18
 
 - Fixed bug in the find_validators function when the number of validators in the new set was increased.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 build = 'build.rs'
 edition = '2021'
 name = 'ever_block'
-version = '1.11.18'
+version = '1.11.19'
 
 [dependencies]
 aes-ctr = '0.6'

--- a/src/cell/mod.rs
+++ b/src/cell/mod.rs
@@ -195,10 +195,6 @@ impl fmt::Display for CellType {
 pub trait CellImpl: Sync + Send {
     fn data(&self) -> &[u8];
     fn raw_data(&self) -> Result<&[u8]>;
-    #[deprecated]
-    fn cell_data(&self) -> &CellData {
-        unimplemented!();
-    }
     fn bit_length(&self) -> usize;
     fn references_count(&self) -> usize;
     fn reference(&self, index: usize) -> Result<Cell>;
@@ -1677,10 +1673,6 @@ impl CellImpl for DataCell {
         Ok(self.cell_data.raw_data())
     }
 
-    fn cell_data(&self) -> &CellData {
-        &self.cell_data
-    }
-
     fn bit_length(&self) -> usize {
         self.cell_data.bit_length()
     }
@@ -1761,10 +1753,6 @@ impl CellImpl for UsageCell {
         self.cell.raw_data()
     }
 
-    fn cell_data(&self) -> &CellData {
-        &self.cell.cell_data()
-    }
-
     fn bit_length(&self) -> usize {
         self.cell.bit_length()
     }
@@ -1831,10 +1819,6 @@ impl CellImpl for VirtualCell {
 
     fn raw_data(&self) -> Result<&[u8]> {
         fail!("Virtual cell doesn't support raw_data()");
-    }
-
-    fn cell_data(&self) -> &CellData {
-        &self.cell.cell_data()
     }
 
     fn bit_length(&self) -> usize {


### PR DESCRIPTION
Deleted deprecated method CellImpl::cell_data